### PR TITLE
Fix UI crashes

### DIFF
--- a/XcodeNueve.sh
+++ b/XcodeNueve.sh
@@ -98,7 +98,7 @@ mkdir $PY_TMP_DIR
 curl -o "$PY_TMP_DIR/python2.pkg" "https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg"
 xar -C $PY_TMP_DIR -xf "$PY_TMP_DIR/python2.pkg"
 mkdir $XCODE_PY_DIR
-tar xvf "$PY_TMP_DIR/Python_Framework.pkg/Payload" -C $XCODE_PY_DIR > /dev/null
+tar xvf "$PY_TMP_DIR/Python_Framework.pkg/Payload" -C $XCODE_PY_DIR &> /dev/null
 rm -rf $PY_TMP_DIR
 
 # Replace Python 2.7 system dependency with a local one

--- a/XcodeNueve.sh
+++ b/XcodeNueve.sh
@@ -88,12 +88,25 @@ else
     fi
 fi
 
-# Remove DebuggerLLDB.ideplugin and LLDB.framework to fix breakage on macOS 12.3 and up (they link against the system Python 2)
-rm -rf "$XCODE/Contents/PlugIns/DebuggerLLDB.ideplugin"
-rm -rf "$XCODE/Contents/SharedFrameworks/LLDB.framework"
+echo "Downloading Python 2.7.18..." 
+echo "Note: It's NOT being installed globally, only in Xcode 9 folder" 
+
+# Download Python 2.7.18 installer to use a part of it for making a working dependency
+PY_TMP_DIR="$TMPDIR/python2.7-installer"
+XCODE_PY_DIR="$XCODE/Contents/SharedFrameworks/Python.framework"
+mkdir $PY_TMP_DIR
+curl -o "$PY_TMP_DIR/python2.pkg" "https://www.python.org/ftp/python/2.7.18/python-2.7.18-macosx10.9.pkg"
+xar -C $PY_TMP_DIR -xf "$PY_TMP_DIR/python2.pkg"
+mkdir $XCODE_PY_DIR
+tar xvf "$PY_TMP_DIR/Python_Framework.pkg/Payload" -C $XCODE_PY_DIR > /dev/null
+rm -rf $PY_TMP_DIR
+
+# Replace Python 2.7 system dependency with a local one
+echo "40727061 74682F50 7974686F 6E2E6672 616D6577 6F726B2F 2E2E2F50 7974686F 6E2E6672 616D6577 6F726B2F 56657273 696F6E73 2F322E37 2F507974 686F6E" |  xxd -r -p -s 0x9e8 - "$XCODE/Contents/SharedFrameworks/LLDB.framework/Versions/A/LLDB"
 
 codesign -f -s $IDENTITY "$XCODE/Contents/SharedFrameworks/DVTKit.framework"
 codesign -f -s $IDENTITY "$XCODE"
 codesign -f -s $IDENTITY "$XCODE/Contents/SharedFrameworks/DVTDocumentation.framework"
 codesign -f -s $IDENTITY "$XCODE/Contents/Frameworks/IDEFoundation.framework"
 codesign -f -s $IDENTITY "$XCODE/Contents/Developer/usr/bin/xcodebuild"
+codesign -f -s $IDENTITY "$XCODE/Contents/SharedFrameworks/LLDB.framework"

--- a/XcodeNueve.sh
+++ b/XcodeNueve.sh
@@ -74,6 +74,9 @@ echo "4E534365 6C6C2E5F 63466C61 6773" |  xxd -r -p -s 0x899801 - "$XCODE/Conten
 echo "64656C65 67617465" |  xxd -r -p -s 0x7bee08 - "$XCODE/Contents/PlugIns/IDEInterfaceBuilderKit.framework/Versions/A/IDEInterfaceBuilderKit"
 echo "64656C65 67617465" |  xxd -r -p -s 0x899894 - "$XCODE/Contents/PlugIns/IDEInterfaceBuilderKit.framework/Versions/A/IDEInterfaceBuilderKit"
 
+# Fix -[DVTSearchFieldCell willDrawVibrantly] method of DVTKit which crashes the whole UI
+echo "66909066 90906690 90" |  xxd -r -p -s 0xB63AE - "$XCODE/Contents/SharedFrameworks/DVTKit.framework/Versions/A/DVTKit"
+
 # Copy libtool from the (presumably newer) installed Xcode.app, to fix crashes on Monterey
 if [ -f "`xcode-select -p`/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool" ]; then
     cp -p "`xcode-select -p`/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool" "$XCODE/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool"

--- a/XcodeNueve.sh
+++ b/XcodeNueve.sh
@@ -77,6 +77,10 @@ echo "64656C65 67617465" |  xxd -r -p -s 0x899894 - "$XCODE/Contents/PlugIns/IDE
 # Fix -[DVTSearchFieldCell willDrawVibrantly] method of DVTKit which crashes the whole UI
 echo "66909066 90906690 90" |  xxd -r -p -s 0xB63AE - "$XCODE/Contents/SharedFrameworks/DVTKit.framework/Versions/A/DVTKit"
 
+# Fix build/clean/test/etc square alerts in -[DVTBezelAlertPanel effectViewForBezel] (uses undocumented & outdated method)
+echo "66906690 669090" |  xxd -r -p -s 0xD0E40 - "$XCODE/Contents/SharedFrameworks/DVTKit.framework/Versions/A/DVTKit"
+echo "66909066 9090" |  xxd -r -p -s 0xD0EA1 - "$XCODE/Contents/SharedFrameworks/DVTKit.framework/Versions/A/DVTKit"
+
 # Copy libtool from the (presumably newer) installed Xcode.app, to fix crashes on Monterey
 if [ -f "`xcode-select -p`/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool" ]; then
     cp -p "`xcode-select -p`/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool" "$XCODE/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool"


### PR DESCRIPTION
I've fixed the main issue which prevented Xcode 9 from opening/creating projects. Also UI don't start without Python 2 dependency, so now the script downloads it from python.org, puts it in Xcode folder and replaces load_dylib with a local version.

UI works great, I did a couple of simple tests, no crashes. Though I wouldn't recommend it as a reliable tool for daily tasks.

<img width="1440" alt="Screenshot 2023-04-12 at 07 27 47" src="https://user-images.githubusercontent.com/44947024/231351151-e669b3a1-48d1-42ff-a056-4840f5cca624.png">
