### PR TITLE
Handle openssl dgst output in newer versions of macOS.

### DIFF
--- a/XcodeNueve.sh
+++ b/XcodeNueve.sh
@@ -13,7 +13,7 @@ check_file_exists() {
 }
 
 check_sha256() {
-    if [ `openssl dgst -sha256 "$1" | sed 's/SHA256(.*)= //'` != "$2" ]; then
+    if [ "`openssl dgst -sha256 "$1" | sed -E 's/SHA(2-)?256(.*)= //'`" != "$2" ]; then
         echo "$0: $1 has an unexpected checksum. Is this an unmodified copy of Xcode 9.4.1?"
         exit 1
     fi


### PR DESCRIPTION
Ventura ships with LibreSSL 3, which outputs 'SHA2-256(...)= ' instead of 'SHA256(...)= '.

Also, quote that command so that a failing regex doesn't trigger word expansion, which results in bad arguments to test(1).